### PR TITLE
Add automatic CI/CD workflow updates for quarto-extension

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
+  schedule:
+    # Run daily at midnight UTC to check for extension updates
+    - cron: '0 0 * * *'
+  repository_dispatch:
+    # Allow external triggers (e.g., from the extension repo)
+    types: [extension-updated, manual-update]
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ Workflow steps:
 4. Upload `_output/` to GitHub Pages.
 5. Build and push Docker image `ghcr.io/mvwestendorp/quarto-review-extension-github-demo:main`.
 
+### Automatic Updates
+
+The workflow automatically checks for extension updates via:
+
+- **Daily Schedule**: Runs at midnight UTC every day to fetch and deploy the latest extension
+- **Manual Trigger**: Use "Run workflow" button in GitHub Actions
+- **Repository Dispatch**: The extension repo can trigger updates via webhook:
+  ```bash
+  curl -X POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer $GITHUB_TOKEN" \
+    https://api.github.com/repos/mvwestendorp/quarto-review-extension-github-demo/dispatches \
+    -d '{"event_type":"extension-updated"}'
+  ```
+
 Requirements:
 - If the extension repo is private, set `EXTENSION_BUNDLE_TOKEN` with a PAT giving
   `contents:read` access.


### PR DESCRIPTION
- Add daily scheduled trigger (midnight UTC) to check for extension updates
- Add repository_dispatch trigger for webhook-based updates from extension repo
- Update README with documentation about automatic update mechanisms
- Supports manual trigger via GitHub Actions UI and programmatic trigger via API

This ensures the demo site stays up-to-date with the latest extension releases automatically.